### PR TITLE
Fix typo and update learning plan tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bienvenido al backend de Tovi, la plataforma de microlearning impulsada por IA. 
     -   [Diagrama del Flujo de Creación de Plan](#diagrama-del-flujo-de-creación-de-plan)
 5.  [Estructura del Proyecto](#estructura-del-proyecto)
 6.  [Orquestación de Agentes LLM](#orquestación-de-agentes-llm)
-    -   [Tovill Analyzer](#1-tovill-analyzerservicets)
+    -   [Skill Analyzer](#1-skill-analyzerservicets)
     -   [Learning Planner](#2-learningplannerservicets)
     -   [Pedagogical Expert](#3-pedagogicalexpertservicets)
     -   [Content Generator](#4-contentgeneratorservicets)
@@ -443,15 +443,15 @@ El código fuente se encuentra en el directorio `src/`.
 
 Ubicados en `src/services/llm/`, cada servicio actúa como un "agente" de IA especializado, con su propio `prompt` de sistema definido en `prompts.ts`.
 
-### 1. `tovillAnalyzer.service.ts`
+### 1. `skillAnalyzer.service.ts`
 -   **Objetivo**: Analizar la habilidad que un usuario desea aprender.
 -   **Función**: Determina si la habilidad es viable para la plataforma (segura, ética, enseñable online), la categoriza, y la descompone en componentes clave.
--   **Salida**: Un objeto `TovillAnalysis` que sirve como base para la planificación.
+-   **Salida**: Un objeto `SkillAnalysis` que sirve como base para la planificación.
 
 ### 2. `learningPlanner.service.ts`
 -   **Objetivo**: Crear un plan de aprendizaje estructurado y personalizado.
 -   **Función**: Se llama en un proceso de dos pasos:
-    1.  **Borrador**: Genera un plan inicial basado en el `TovillAnalysis` y las preferencias del usuario.
+    1.  **Borrador**: Genera un plan inicial basado en el `SkillAnalysis` y las preferencias del usuario.
     2.  **Refinamiento**: Recibe el análisis del `PedagogicalExpert` y lo utiliza para mejorar y finalizar el plan, ajustando la estructura, actividades y recursos.
 -   **Salida**: Un objeto `LearningPlan` detallado.
 

--- a/src/controllers/learningPlan.controller.ts
+++ b/src/controllers/learningPlan.controller.ts
@@ -38,7 +38,8 @@ export const createLearningPlanController = async (req: AuthenticatedRequest, re
     const { onboardingPrefs, skillAnalysis } = CreatePlanInputSchema.parse(req.body);
     const user = req.user!; // El middleware isAuthenticated garantiza que user exista
 
-    // Parsear tiempo de string a número (ej: "15 minutes" → 15)
+    // `onboardingPrefs.time` llega como '30 minutes', '1h', etc.  Extraemos
+    // los dígitos para convertirlo a minutos y almacenarlo de forma numérica.
     const availableTimeMinutes = parseInt(onboardingPrefs.time?.replace(/\D/g, '') || '15', 10);
     
     // Guardar las preferencias del usuario

--- a/tests/api/learningPlan.spec.ts
+++ b/tests/api/learningPlan.spec.ts
@@ -47,7 +47,8 @@ describe('Learning Plan API (/api/learning-plan)', () => {
 
   describe('POST /create', () => {
     it('debería devolver 401 Unauthorized si no se provee un token', async () => {
-        const onboardingPrefs = { skill: 'Test', experienceLevel: 'BEGINNER', availableTimeMinutes: 10, motivation: 'Test', goal: 'Test' };
+        // Propiedades mínimas para provocar el error de autenticación
+        const onboardingPrefs = { skill: 'Test', experience: 'BEGINNER', time: '10 minutes', motivation: 'Test', goal: 'Test' };
         const skillAnalysis = { skillName: 'Test', skillCategory: 'TECHNICAL', marketDemand: 'HIGH', components: [], learningPathRecommendation: '', realWorldApplications: [], complementarySkills: [], isSkillValid: true };
         
         const unauthedClient = axios.create({ baseURL: API_BASE_URL });
@@ -60,7 +61,7 @@ describe('Learning Plan API (/api/learning-plan)', () => {
     });
 
     it('debería devolver 403 Forbidden si se provee un token inválido', async () => {
-        const onboardingPrefs = { skill: 'Test', experienceLevel: 'BEGINNER', availableTimeMinutes: 10, motivation: 'Test', goal: 'Test' };
+        const onboardingPrefs = { skill: 'Test', experience: 'BEGINNER', time: '10 minutes', motivation: 'Test', goal: 'Test' };
         const skillAnalysis = { skillName: 'Test', skillCategory: 'TECHNICAL', marketDemand: 'HIGH', components: [], learningPathRecommendation: '', realWorldApplications: [], complementarySkills: [], isSkillValid: true };
         
         const invalidApiClient = axios.create({ 
@@ -79,7 +80,7 @@ describe('Learning Plan API (/api/learning-plan)', () => {
     it('debería crear un plan de aprendizaje con un token válido y datos correctos', async () => {
         expect(testUser?.token).toBeDefined();
 
-        const onboardingPrefs = { skill: 'TypeScript', experience: 'BEGINNER', availableTimeMinutes: 30, motivation: 'Career Change', goal: 'Build a web app' };
+        const onboardingPrefs = { skill: 'TypeScript', experience: 'BEGINNER', time: '30 minutes', motivation: 'Career Change', goal: 'Build a web app' };
         const skillAnalysis = {
             skill_name: 'TypeScript',
             skill_category: 'TECHNICAL',
@@ -100,10 +101,11 @@ describe('Learning Plan API (/api/learning-plan)', () => {
         };
         
         const response = await apiClient.post('/learning-plan/create', { onboardingPrefs, skillAnalysis });
-        
+
         expect(response.status).toBe(201);
         expect(response.data.message).toBe('Learning plan created successfully!');
-        expect(response.data.planId).toBeDefined();
+        expect(typeof response.data.planId).toBe('string');
+        expect(response.data.planId.length).toBeGreaterThan(0);
     });
   });
 }); 


### PR DESCRIPTION
## Summary
- document "Skill Analyzer" agent in README
- clarify time-parsing logic when creating learning plans
- update learning-plan test data and strengthen assertions

## Testing
- `npm test` *(fails: Jest fails to parse TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_6855a242bda483298d77977a9b7c15a9