### PR TITLE
Fix Jest TypeScript setup

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testTimeout: 30000,
+};


### PR DESCRIPTION
## Summary
- add missing Jest config for TypeScript tests

## Testing
- `pnpm test` *(fails: AggregateError from axios / Firebase emulator not running)*

------
https://chatgpt.com/codex/tasks/task_e_6855960634d08329b148b808f572a2bc