### PR TITLE
Improve schema reuse and error handling

### DIFF
--- a/dataconnect/connector/mutations.gql
+++ b/dataconnect/connector/mutations.gql
@@ -18,6 +18,20 @@ mutation CreateUser(
   })
 }
 
+mutation CreateUserPreference(
+  $userFirebaseUid: String!, $skill: String!, $experienceLevel: String!,
+  $motivation: String!, $availableTimeMinutes: Int!, $goal: String!,
+  $learningStyle: String, $preferredStudyTime: String,
+  $learningContext: String, $challengePreference: String
+) @auth(level: NO_ACCESS) {
+  userPreference_insert(data: {
+    userFirebaseUid: $userFirebaseUid, skill: $skill, experienceLevel: $experienceLevel,
+    motivation: $motivation, availableTimeMinutes: $availableTimeMinutes, goal: $goal,
+    learningStyle: $learningStyle, preferredStudyTime: $preferredStudyTime,
+    learningContext: $learningContext, challengePreference: $challengePreference
+  })
+}
+
 # --- Learning Plan & Content Mutations (Granular) ---
 
 mutation CreateLearningPlanBase(

--- a/src/controllers/content.controller.ts
+++ b/src/controllers/content.controller.ts
@@ -44,8 +44,8 @@ export const generateNextDayContentController = async (req: AuthenticatedRequest
       data: result.data,
     });
 
-  } catch (error: any) {
-    console.error(`CRITICAL: Unhandled error in generateNextDayContentController for plan ${learningPlanId}, user ${userId}. Error: ${error.message}`, { stack: error.stack });
+  } catch (error: unknown) {
+    console.error(`CRITICAL: Unhandled error in generateNextDayContentController for plan ${learningPlanId}, user ${userId}.`, error);
     res.status(500).json({ message: 'An unexpected server error occurred while generating content.' });
   }
 };

--- a/src/controllers/learningPlan.controller.ts
+++ b/src/controllers/learningPlan.controller.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { z } from 'zod';
-import { LearningPlan, SkillAnalysisSchema } from '../services/llm/schemas';
+import { LearningPlan, SkillAnalysisSchema, OnboardingPreferencesSchema } from '../services/llm/schemas';
 import * as DataConnectService from '../services/dataConnect.service';
 import * as llmService from '../services/llm/learningPlanner.service';
 import * as pedagogicalExpert from '../services/llm/pedagogicalExpert.service';
@@ -9,18 +9,7 @@ import * as ContentOrchestrator from '../services/contentOrchestrator.service';
 
 // Esquema de validación para la creación del plan (copiado de onboarding.controller.ts)
 const CreatePlanInputSchema = z.object({
-  onboardingPrefs: z.object({
-    skill: z.string().min(1, 'Skill is required.'),
-    experience: z.enum(['Beginner', 'Intermediate', 'Advanced']),
-    time: z.string().min(1, 'Time commitment is required.'), // ej: "10min / day"
-    motivation: z.string().min(1, 'Motivation is required.'), // ej: "Career Growth"
-    goal: z.string().optional(),
-    // Nuevos campos opcionales para mejor personalización
-    learning_style: z.enum(['visual', 'auditory', 'kinesthetic', 'reading']).optional(),
-    preferred_study_time: z.enum(['morning', 'afternoon', 'evening', 'flexible']).optional(),
-    learning_context: z.enum(['career_change', 'skill_improvement', 'hobby', 'academic', 'promotion']).optional(),
-    challenge_preference: z.enum(['gradual', 'moderate', 'intense']).optional(),
-  }),
+  onboardingPrefs: OnboardingPreferencesSchema,
   skillAnalysis: SkillAnalysisSchema,
 });
 
@@ -192,7 +181,7 @@ export const createLearningPlanController = async (req: AuthenticatedRequest, re
       initialContent: day1Result.success ? day1Result.data : null,
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (error instanceof z.ZodError) {
       // 🔍 DEBUG: Logs detallados de errores de validación Zod
       console.error('❌ BACKEND - Error de validación Zod:', JSON.stringify(error.errors, null, 2));
@@ -240,7 +229,7 @@ export const getCurrentLearningPlanController = async (req: AuthenticatedRequest
       plan: currentPlan,
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in getCurrentLearningPlanController:', error);
     res.status(500).json({ message: 'Internal server error.' });
   }
@@ -279,7 +268,7 @@ export const getLearningPlanByIdController = async (req: AuthenticatedRequest, r
       plan: plan,
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in getLearningPlanByIdController:', error);
     res.status(500).json({ message: 'Internal server error.' });
   }

--- a/src/controllers/onboarding.controller.ts
+++ b/src/controllers/onboarding.controller.ts
@@ -1,20 +1,10 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { analyzeSkillWithOpenAI, UserSkillContext } from '../services/llm/skillAnalyzer.service';
+import { OnboardingPreferencesSchema } from '../services/llm/schemas';
 
 // Esquema de validación para la entrada del onboarding (lo mantenemos cerca del controlador que lo usa)
-const OnboardingInputSchema = z.object({
-  skill: z.string().min(1, 'Skill is required.'),
-  experience: z.enum(['Beginner', 'Intermediate', 'Advanced']),
-  time: z.string().min(1, 'Time commitment is required.'), // ej: "10min / day"
-  motivation: z.string().min(1, 'Motivation is required.'), // ej: "Career Growth"
-  goal: z.string().optional(),
-  // Nuevos campos opcionales para mejor personalización
-  learning_style: z.enum(['visual', 'auditory', 'kinesthetic', 'reading']).optional(),
-  preferred_study_time: z.enum(['morning', 'afternoon', 'evening', 'flexible']).optional(),
-  learning_context: z.enum(['career_change', 'skill_improvement', 'hobby', 'academic', 'promotion']).optional(),
-  challenge_preference: z.enum(['gradual', 'moderate', 'intense']).optional(),
-});
+const OnboardingInputSchema = OnboardingPreferencesSchema;
 
 /**
  * Controlador para analizar una habilidad durante el onboarding.

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -59,7 +59,7 @@ export const getUserStatsController = async (req: AuthenticatedRequest, res: Res
       }
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in getUserStatsController:', error);
     res.status(500).json({ message: 'Internal server error.' });
   }
@@ -89,7 +89,7 @@ export const getUserStreakController = async (req: AuthenticatedRequest, res: Re
       }
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in getUserStreakController:', error);
     res.status(500).json({ message: 'Internal server error.' });
   }
@@ -112,8 +112,8 @@ export const getUserXPController = async (req: AuthenticatedRequest, res: Respon
       }
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in getUserXPController:', error);
     res.status(500).json({ message: 'Internal server error.' });
   }
-}; 
+};

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -50,9 +50,9 @@ export const isAuthenticated = async (req: AuthenticatedRequest, res: Response, 
     req.user = userProfile;
     
     next();
-  } catch (error: any) {
-    console.error(`Authentication error: ${error.message}`);
+  } catch (error: unknown) {
+    console.error('Authentication error:', error);
     // El token puede ser inválido, expirado, etc.
     return res.status(403).send({ message: 'Forbidden: Invalid or expired token.' });
   }
-}; 
+};

--- a/src/services/dataConnect.service.ts
+++ b/src/services/dataConnect.service.ts
@@ -91,8 +91,8 @@ async function executeGraphQL<TData = any, TVariables = Record<string, any>>(
       logger.error(`Errores en GraphQL para op '${opName}':`, JSON.stringify(response.errors, null, 2));
     }
     return response;
-  } catch (error: any) {
-    logger.error(`Error fundamental ejecutando GraphQL: ${error.message}`, error);
+  } catch (error: unknown) {
+    logger.error('Error fundamental ejecutando GraphQL:', error);
     throw error;
   }
 }

--- a/src/services/dataConnect.types.ts
+++ b/src/services/dataConnect.types.ts
@@ -118,8 +118,6 @@ export interface DbUser {
     platform?: string | null;
     photoUrl?: string | null;
     emailVerified?: boolean | null;
-    llmKeyInsights?: string[] | null;
-    llmOverallEngagementScore?: number | null;
     fcmTokens?: string[] | null;
     lastSignInAt?: string | null; // Timestamp
     isActive?: boolean | null;

--- a/src/services/firebase.service.ts
+++ b/src/services/firebase.service.ts
@@ -22,8 +22,8 @@ function initialize() {
       const credential = admin.credential.cert(serviceAccountPath);
       admin.initializeApp({ credential });
       logger.log('Firebase Admin App initialized successfully (default app).');
-    } catch (error: any) {
-      logger.error(`CRITICAL: Failed to initialize Firebase Admin SDK. Error: ${error.message}`);
+    } catch (error: unknown) {
+      logger.error('CRITICAL: Failed to initialize Firebase Admin SDK.', error);
       return; // No continuar si falla la inicialización de admin
     }
   }
@@ -39,7 +39,7 @@ function initialize() {
       if (IS_EMULATOR) {
         logger.log(`Firebase Data Connect: Emulator detected. The SDK will connect to the emulator.`);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       logger.error('Failed to initialize Firebase Data Connect SDK:', error);
     }
   }
@@ -71,8 +71,9 @@ export async function verifyFirebaseIdToken(idToken: string): Promise<DecodedIdT
   try {
     const decodedToken = await admin.auth().verifyIdToken(idToken);
     return decodedToken;
-  } catch (error: any) {
-    logger.warn(`Error verificando Firebase ID Token: ${error.code} - ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    logger.warn(`Error verificando Firebase ID Token: ${err.code} - ${err.message}`);
     throw error;
   }
 }
@@ -89,8 +90,9 @@ export async function createUserInAuth(
     const userRecord = await admin.auth().createUser(userData);
     logger.info(`Usuario creado en Firebase Auth con UID: ${userRecord.uid}`);
     return userRecord;
-  } catch (error: any) {
-    logger.error(`Error creando usuario en Firebase Auth para email ${userData.email}: ${error.code} - ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    logger.error(`Error creando usuario en Firebase Auth para email ${userData.email}: ${err.code} - ${err.message}`);
     throw error;
   }
 }
@@ -104,8 +106,9 @@ export async function getUserFromAuth(uid: string): Promise<admin.auth.UserRecor
   try {
     const userRecord = await admin.auth().getUser(uid);
     return userRecord;
-  } catch (error: any) {
-    logger.error(`Error obteniendo usuario de Firebase Auth con UID ${uid}: ${error.code} - ${error.message}`);
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    logger.error(`Error obteniendo usuario de Firebase Auth con UID ${uid}: ${err.code} - ${err.message}`);
     throw error;
   }
 }
@@ -142,10 +145,11 @@ export async function sendFcmNotification(
     const response = await admin.messaging().send(message);
     logger.info(`Notificación FCM enviada exitosamente a token ${deviceToken.substring(0,20)}... : ${response}`);
     return true;
-  } catch (error: any) {
-    logger.error(`Error enviando notificación FCM al token ${deviceToken.substring(0,20)}...: ${error.code} - ${error.message}`);
-    if (error.code === 'messaging/registration-token-not-registered' || 
-        error.code === 'messaging/invalid-registration-token') {
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    logger.error(`Error enviando notificación FCM al token ${deviceToken.substring(0,20)}...: ${err.code} - ${err.message}`);
+    if (err.code === 'messaging/registration-token-not-registered' ||
+        err.code === 'messaging/invalid-registration-token') {
       logger.info(`Token FCM inválido o no registrado: ${deviceToken}. Debería ser eliminado de la base de datos.`);
     }
     return false;

--- a/src/services/llm/openai.service.ts
+++ b/src/services/llm/openai.service.ts
@@ -89,18 +89,18 @@ export async function getOpenAiChatCompletion(
       content: messageContent,
       usage: completion.usage,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error llamando al API de OpenAI:', error);
     let errorMessage = 'Error desconocido al contactar OpenAI.';
-    if (error.response) {
+    if ((error as any).response) {
       // El API devolvió un error (ej. 4xx, 5xx)
-      errorMessage = `Error de OpenAI API: ${error.response.status} - ${JSON.stringify(error.response.data)}`;
-    } else if (error.request) {
+      errorMessage = `Error de OpenAI API: ${(error as any).response.status} - ${JSON.stringify((error as any).response.data)}`;
+    } else if ((error as any).request) {
       // La solicitud se hizo pero no se recibió respuesta
       errorMessage = 'No se recibió respuesta de OpenAI API.';
-    } else if (error.message) {
+    } else if ((error as Error).message) {
       // Algo más ocurrió
-      errorMessage = error.message;
+      errorMessage = (error as Error).message;
     }
     return {
       success: false,


### PR DESCRIPTION
## Summary
- centralize onboarding schemas in `schemas.ts`
- reference onboarding schemas from controllers
- enforce unknown typing in catch blocks
- remove unused analytics fields from `DbUser`
- add missing mutation to GraphQL operations

## Testing
- `npm run test:e2e` *(fails: Data Connect emulator shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_6855c840cadc8329b33d370273737994