### PR TITLE
Refactor auth profile sync

### DIFF
--- a/src/api/auth.routes.ts
+++ b/src/api/auth.routes.ts
@@ -1,22 +1,11 @@
 import { Router } from 'express';
-import {
-  signUpController,
-  socialSignInController,
-} from '../controllers/auth.controller';
+import { syncProfileController } from '../controllers/auth.controller';
 
 const router = Router();
 
-/**
- * @route   POST /api/auth/signup
- * @desc    Registra un nuevo usuario con email y contraseña.
- * @access  Public
- */
-router.post('/signup', signUpController);
-
-// Ruta para manejar el login/signup con proveedores sociales (Google, Apple)
-// Esta ruta no usa `isAuthenticated` porque maneja tanto a usuarios nuevos como existentes.
-// La verificación del token se hace dentro del controlador.
-router.post('/social-signin', socialSignInController);
+// Ruta que sincroniza el perfil del usuario autenticado (email o social).
+// No requiere middleware isAuthenticated porque la verificación se realiza dentro del controlador.
+router.post('/sync-profile', syncProfileController);
 
 // No se necesita una ruta de 'login' en el backend para la autenticación estándar de Firebase.
 // El cliente maneja el login con el SDK de Firebase y obtiene un ID Token.

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,128 +1,14 @@
 import { Request, Response } from 'express';
-import { z } from 'zod';
 import * as DataConnectService from '../services/dataConnect.service';
 import * as FirebaseService from '../services/firebase.service';
-import { AuthProvider, DbUser, Platform } from '../services/dataConnect.types';
-
-// Esquema de validación para el registro
-const SignUpSchema = z.object({
-  email: z.string().email('Invalid email format.'),
-  name: z.string().min(1, 'Name is required.'),
-  firebaseUid: z.string().min(1, 'Firebase UID is required.').optional(), // Hacerlo opcional por compatibilidad
-});
+import { AuthProvider, DbUser } from '../services/dataConnect.types';
 
 /**
- * Controlador para registrar un nuevo usuario.
- * Asume que el usuario YA existe en Firebase Auth (creado por el frontend)
- * y solo crea el perfil en la base de datos de Data Connect.
+ * Controlador para sincronizar el perfil del usuario autenticado en nuestra base de datos.
+ * Recibe un ID Token de Firebase (ya sea de autenticación por email o social) y
+ * aplica una lógica de "obtener o crear" en la DB.
  */
-export const signUpController = async (req: Request, res: Response) => {
-  try {
-    // 1. Validar la entrada usando el esquema Zod
-    const { email, name, firebaseUid } = SignUpSchema.parse(req.body);
-
-    // 2. Si no se proporciona el UID, intentar obtenerlo del token de autorización
-    let uid = firebaseUid;
-    if (!uid) {
-      const { authorization } = req.headers;
-      if (!authorization || !authorization.startsWith('Bearer ')) {
-        return res.status(401).json({ 
-          message: 'Unauthorized: Firebase UID required in body or token in Authorization header.' 
-        });
-      }
-      
-      const token = authorization.split('Bearer ')[1];
-      if (!token) {
-        return res.status(401).json({ message: 'Unauthorized: No token provided.' });
-      }
-
-      try {
-        const decodedToken = await FirebaseService.verifyFirebaseIdToken(token);
-        uid = decodedToken.uid;
-        console.log(`Using UID from token: ${uid}`);
-      } catch (error: unknown) {
-        console.error('Error verifying token:', error);
-        return res.status(401).json({ message: 'Invalid Firebase token.' });
-      }
-    }
-
-    // 3. Verificar que el usuario existe en Firebase Auth
-    console.log(`Verifying user exists in Firebase Auth for UID: ${uid}...`);
-    let userRecord;
-    try {
-      userRecord = await FirebaseService.getUserFromAuth(uid);
-    } catch (error: unknown) {
-      if ((error as { code?: string }).code === 'auth/user-not-found') {
-        return res.status(404).json({
-          message: 'User not found in Firebase Auth. Please ensure the user is created in Firebase first.'
-        });
-      }
-      throw error;
-    }
-    console.log(`User verified in Firebase Auth: ${userRecord.email}`);
-
-    // 4. Verificar si el usuario ya existe en nuestra base de datos
-    const existingUser = await DataConnectService.getUserByFirebaseUid(uid);
-    if (existingUser) {
-      console.log(`User already exists in database: ${existingUser.email}`);
-      return res.status(200).json({
-        message: 'User already registered!',
-        user: {
-          uid: existingUser.firebaseUid,
-          email: existingUser.email,
-          name: existingUser.name,
-        },
-      });
-    }
-
-    // 5. Crear el registro del usuario en nuestra base de datos (Data Connect)
-    console.log(`Creating user profile in Data Connect DB for UID: ${uid}...`);
-    const newUserInput: DbUser = {
-      firebaseUid: uid,
-      email: userRecord.email!,
-      name: name || userRecord.displayName || userRecord.email!.split('@')[0],
-      authProvider: AuthProvider.EMAIL,
-      emailVerified: userRecord.emailVerified,
-    };
-    const createdUserInDb = await DataConnectService.createUser(newUserInput);
-
-    if (!createdUserInDb) {
-      console.error(`CRITICAL: Failed to create user profile in Data Connect DB for UID: ${uid}`);
-      return res.status(500).json({ message: 'Failed to create user profile in database.' });
-    }
-    console.log(`User profile created in Data Connect DB for UID: ${createdUserInDb.firebaseUid}`);
-
-    // 6. Devolver la respuesta
-    res.status(201).json({
-      message: 'User registered successfully!',
-      user: {
-        uid: newUserInput.firebaseUid,
-        email: newUserInput.email,
-        name: newUserInput.name,
-      },
-    });
-  } catch (error: unknown) {
-    // Manejar errores de validación de Zod
-    if (error instanceof z.ZodError) {
-      const errorMessage = error.errors.map(e => e.message).join(', ');
-      return res.status(400).json({ message: errorMessage, errors: error.errors });
-    }
-    
-    // Loguear el error completo para facilitar la depuración
-    const errorInfo = error instanceof Error 
-      ? { message: error.message, code: (error as any).code, stack: error.stack }
-      : { message: String(error), code: undefined, stack: undefined };
-    console.error('Error in signUpController:', errorInfo);
-    res.status(500).json({ message: 'Internal server error during user registration.' });
-  }
-};
-
-/**
- * Controlador para manejar el inicio de sesión o registro con proveedores sociales (Google, Apple).
- * El cliente debe enviar el ID Token de Firebase en el header de autorización.
- * Este controlador implementa una lógica de "obtener o crear" (get or create).
- */
-export const socialSignInController = async (req: Request, res: Response) => {
+export const syncProfileController = async (req: Request, res: Response) => {
   const { authorization } = req.headers;
   
   if (!authorization || !authorization.startsWith('Bearer ')) {
@@ -191,7 +77,7 @@ export const socialSignInController = async (req: Request, res: Response) => {
       });
     }
   } catch (error: unknown) {
-    console.error('Error in socialSignInController:', error);
+    console.error('Error in syncProfileController:', error);
     // Si el error es por un token inválido, devolver 403
     if ((error as { code?: string }).code && (error as { code?: string }).code!.startsWith('auth/')) {
       return res.status(403).json({ message: 'Forbidden: Invalid authentication token.' });

--- a/tests/api/content.spec.ts
+++ b/tests/api/content.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import * as admin from 'firebase-admin';
-import { getTestUserAuthToken } from '../helpers/auth.helper';
+import { createTestUserAndGetToken } from '../helpers/auth.helper';
 import * as crypto from 'crypto';
 
 const API_BASE_URL = `http://localhost:${process.env.PORT || 8080}/api`;
@@ -19,10 +19,13 @@ describe('Content API (/api/content)', () => {
 
         const email = generateRandomEmail();
         const password = 'password123';
-        const signupResponse = await axios.post(`${API_BASE_URL}/auth/signup`, { email, password, name: 'Content Tester' });
-        testUser = { uid: signupResponse.data.user.uid, email };
-        
-        testUser.token = await getTestUserAuthToken(email, password);
+        const { uid, token } = await createTestUserAndGetToken(email, password);
+        testUser = { uid, email, token };
+        await axios.post(
+            `${API_BASE_URL}/auth/sync-profile`,
+            {},
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
 
         apiClient = axios.create({ 
             baseURL: API_BASE_URL,

--- a/tests/api/learningPlan.spec.ts
+++ b/tests/api/learningPlan.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import * as admin from 'firebase-admin';
-import { getTestUserAuthToken } from '../helpers/auth.helper';
+import { createTestUserAndGetToken } from '../helpers/auth.helper';
 
 const API_BASE_URL = `http://localhost:${process.env.PORT || 8080}/api`;
 
@@ -20,13 +20,13 @@ describe('Learning Plan API (/api/learning-plan)', () => {
 
     const email = generateRandomEmail();
     const password = 'password123';
-    
-    // 1. Registrar el usuario a través del endpoint de signup
-    const signupResponse = await axios.post(`${API_BASE_URL}/auth/signup`, { email, password, name: 'Plan Tester' });
-    testUser = { uid: signupResponse.data.user.uid, email };
-    
-    // 2. Obtener el token de autenticación del usuario usando el helper.
-    testUser.token = await getTestUserAuthToken(email, password);
+    const { uid, token } = await createTestUserAndGetToken(email, password);
+    testUser = { uid, email, token };
+    await axios.post(
+      `${API_BASE_URL}/auth/sync-profile`,
+      {},
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
     
     // Crear una instancia de axios pre-configurada
     apiClient = axios.create({ 

--- a/tests/api/user.spec.ts
+++ b/tests/api/user.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import * as admin from 'firebase-admin';
-import { getTestUserAuthToken } from '../helpers/auth.helper';
+import { createTestUserAndGetToken } from '../helpers/auth.helper';
 
 const API_BASE_URL = `http://localhost:${process.env.PORT || 8080}/api`;
 
@@ -18,17 +18,13 @@ describe('User API (/api/user)', () => {
 
         const email = generateRandomEmail();
         const password = 'password123';
-        
-        // 1. Crear usuario de prueba
-        const signupResponse = await axios.post(`${API_BASE_URL}/auth/signup`, { 
-            email, 
-            password, 
-            name: 'User Stats Tester' 
-        });
-        testUser = { uid: signupResponse.data.user.uid, email };
-        
-        // 2. Obtener token de autenticación
-        testUser.token = await getTestUserAuthToken(email, password);
+        const { uid, token } = await createTestUserAndGetToken(email, password);
+        testUser = { uid, email, token };
+        await axios.post(
+            `${API_BASE_URL}/auth/sync-profile`,
+            {},
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
 
         // 3. Configurar cliente HTTP autenticado
         apiClient = axios.create({ 


### PR DESCRIPTION
## Summary
- consolidate auth controllers into `syncProfileController`
- remove `/signup` route and add `/sync-profile`
- provide helper to create Firebase auth users for tests
- update all authentication-related tests for new flow

## Testing
- `pnpm test` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855d1f4fc848329b876adbe337a7673