### PR TITLE
Fix Data Connect config usage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,8 +3,9 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 
 // Importar el router principal de la API (asumiendo que hay un index.ts en api/)
-import apiRouter from './api'; 
+import apiRouter from './api';
 import { errorHandler, notFoundHandler } from './utils/errorHandler';
+import logger from './utils/logger';
 
 // Cargar variables de entorno
 dotenv.config();
@@ -31,6 +32,9 @@ app.use(notFoundHandler);
 app.use(errorHandler);
 
 // Iniciar el servidor
-app.listen(PORT, () => {});
+// Start the server and log the startup
+app.listen(PORT, () => {
+  logger.info(`Server listening on port ${PORT}`);
+});
 
 export default app;

--- a/src/services/firebase.service.ts
+++ b/src/services/firebase.service.ts
@@ -10,8 +10,10 @@ let dataConnectInstance: DataConnect | null = null;
 
 // --- CONSTANTES DE CONFIGURACIÓN ---
 const IS_EMULATOR = process.env.FIREBASE_AUTH_EMULATOR_HOST || process.env.NODE_ENV === 'test';
-const DATA_CONNECT_SERVICE_ID = 'skillix-db-service';
-const DATA_CONNECT_LOCATION = 'us-central1';
+// Use configuration values for Data Connect service to allow environment based
+// customization. Defaults are provided for local development.
+const DATA_CONNECT_SERVICE_ID = config.dataConnectServiceId || 'skillix-db-service';
+const DATA_CONNECT_LOCATION = config.dataConnectLocation || 'us-central1';
 
 function initialize() {
   // Inicializa la app de admin si no existe.


### PR DESCRIPTION
## 🎯 Summary
- load Data Connect configuration from env
- log server startup

## 🔧 Technical Changes
- use `config.dataConnectServiceId` and `config.dataConnectLocation`
- added logger import and startup log in `app.ts`

## 🧪 Testing
- `pnpm test:offline`
- `pnpm lint`
- `npx tsc --noEmit`

## 🛡️ Security Review
- No sensitive data exposed in these changes
- Firebase Admin initialization still relies on service account file

## 📊 Performance Impact
- No runtime performance impact


------
https://chatgpt.com/codex/tasks/task_e_68571d462c8c8329a417a26c4f565680